### PR TITLE
Use Reliable Syntax for Finding Active Products

### DIFF
--- a/app/workers/workarea/generate_sitemaps.rb
+++ b/app/workers/workarea/generate_sitemaps.rb
@@ -29,7 +29,7 @@ module Workarea
         # Products
         #
         #
-        Catalog::Product.active.each_by(per_batch) do |product|
+        Catalog::Product.all.each_by(per_batch) do |product|
           next unless product.active?
           add generator.product_path(product), changefreq: 'daily'
         end


### PR DESCRIPTION
The sitemap generator needs to know all active products in order to
add them as links. Previously, this plugin used the `.active` scope
which has been deprecated as of Workarea v3.5.0, so an update is
necessary to have it use the newer, more reliable syntax in a world of
segmented activation...

SITEMAPS-2